### PR TITLE
Slight Redundancy in World Based Split

### DIFF
--- a/LoadRemovers/KH2.asl
+++ b/LoadRemovers/KH2.asl
@@ -285,9 +285,10 @@ split
 					vars.splitTimer = 100;
 					break;
 				case "05-03-14":
-					if (settings[oldLocation+"-W"] && currentLocation == "0F-00-00") 
-						vars.splitTimer = 3600;
+					if (currentLocation == "0F-00-00") {
+						vars.splitTimer = 1800;
 						return settings[oldLocation+"-W"];
+					}
 					break;	
 				default:
 					break;

--- a/LoadRemovers/KH2.asl
+++ b/LoadRemovers/KH2.asl
@@ -285,7 +285,7 @@ split
 					vars.splitTimer = 100;
 					break;
 				case "05-03-14":
-					if (currentLocation == "0F-00-00") {
+					if (current.worldID == 0x0F) {
 						vars.splitTimer = 1800;
 						return settings[oldLocation+"-W"];
 					}


### PR DESCRIPTION
+ Smaller IF to speed up the process. Hoping it splits more consistently. It bugged out and sometimes didn't split. (very rare)
+ Fixed it always splitting upon leaving checked rooms. It would only increase splitTimer if leaving the world. (My bad, syntax issue)